### PR TITLE
Category link fix

### DIFF
--- a/eshop-mongodb/models/products.js
+++ b/eshop-mongodb/models/products.js
@@ -87,7 +87,7 @@ NEWSCHEMA('Product').make(function(schema) {
 				if (linker_detail)
 					item.linker = linker_detail.url.format(item.linker);
 				if (linker_category)
-					item.linker_category = linker_category.url.format(item.linker_category);
+					item.linker_category = linker_category.url + item.linker_category;
 			});
 
 			if (!data.pages)

--- a/eshop-postgresql/models/products.js
+++ b/eshop-postgresql/models/products.js
@@ -107,7 +107,7 @@ NEWSCHEMA('Product').make(function(schema) {
 				if (linker_detail)
 					item.linker = linker_detail.url.format(item.linker);
 				if (linker_category)
-					item.linker_category = linker_category.url.format(item.linker_category);
+					item.linker_category = linker_category.url + item.linker_category;
 			});
 
 			if (!data.pages)

--- a/eshop/models/products.js
+++ b/eshop/models/products.js
@@ -70,7 +70,7 @@ NEWSCHEMA('Product').make(function(schema) {
 				if (linker_detail)
 					doc.linker = linker_detail.url.format(doc.linker);
 				if (linker_category)
-					doc.linker_category = linker_category.url.format(doc.linker_category);
+					doc.linker_category = linker_category.url + doc.linker_category;
 				delete doc.body;
 			}
 


### PR DESCRIPTION
This fixes linker_category property of product pointing to /shop/ instead of /shop/<category>/
Since F.sitemap('category', true); => /products/ can't be used with .format(item.linker_category); as there's no placeholder like {0}

See https://eshop.totaljs.com/ and click on _**Short**_ category link on first item. It points to https://eshop.totaljs.com/shop/ without category
