### PR TITLE
Fixed config variable usage in admin index page

### DIFF
--- a/themes/admin/views/index.html
+++ b/themes/admin/views/index.html
@@ -31,7 +31,7 @@
 
 	<header>
 		<nav>
-			<a href="/" title="@{'%name'}" target="_blank"><i class="fa fa-globe"></i></a>
+			<a href="/" title="@{config.name}" target="_blank"><i class="fa fa-globe"></i></a>
 			<button class="navigation"><i class="fa fa-navicon"></i>@(Options)</button>
 		</nav>
 		<div class="title"></div>


### PR DESCRIPTION
If the config contains an apostrophe in the name configuration, this will break the builder syntax in https://github.com/totaljs/framework/blob/769cf8586d03df5a766cd316030d7eafcae8fd57/internal.js#L1981